### PR TITLE
Pass props to TextInput and stop capitalizing email address.

### DIFF
--- a/src/components/auth/Signup.js
+++ b/src/components/auth/Signup.js
@@ -57,6 +57,7 @@ class Signup extends Component {
             name="email"
             component={Input}
             placeholder="Email"
+            autoCapitalize={"none"}
           />
         </Item>
 

--- a/src/components/auth/Signup.js
+++ b/src/components/auth/Signup.js
@@ -57,7 +57,7 @@ class Signup extends Component {
             name="email"
             component={Input}
             placeholder="Email"
-            autoCapitalize={"none"}
+            autoCapitalize={'none'}
           />
         </Item>
 

--- a/src/components/common/Input.js
+++ b/src/components/common/Input.js
@@ -26,6 +26,7 @@ const Input = (props) => {
     secureTextEntry,
     multiline,
     containerStyle,
+    ...otherProps,
   } = props;
 
   return (
@@ -38,6 +39,7 @@ const Input = (props) => {
         style={InputText}
         onChangeText={value => onChange(value)}
         value={value}
+        {...otherProps}
       />
       {touched && error &&
         <View>

--- a/src/components/common/Input.js
+++ b/src/components/common/Input.js
@@ -26,7 +26,7 @@ const Input = (props) => {
     secureTextEntry,
     multiline,
     containerStyle,
-    ...otherProps,
+    ...otherProps
   } = props;
 
   return (


### PR DESCRIPTION
Minor tweak to support passing props to TextInput component
and using autoCapitalize={"none"} prop on email field.